### PR TITLE
Fix for issue #4 

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -2,7 +2,7 @@
 
 namespace AnyCloud;
 
-use AnyCloud\Form\Configform;
+use AnyCloud\Form\ConfigForm;
 use Omeka\Module\AbstractModule;
 use Omeka\Module\Exception\ModuleCannotInstallException;
 use Zend\Mvc\Controller\AbstractController;

--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -8,6 +8,9 @@ use Zend\Form\Form;
 
 class ConfigForm extends Form
 {
+    
+    protected $globalSettings;
+    
     /**
      * Initialize the configuration form.
      */
@@ -21,6 +24,14 @@ class ConfigForm extends Form
         $this->addS3('scaleway', 'Scaleway Object Storage', 'Scaleway');
         $this->addRackspace();
         $this->addDropbox();
+    }
+    
+     /**
+     * Set configuration settings.
+     */
+    public function setGlobalSettings($globalSettings)
+    {
+        $this->globalSettings = $globalSettings;
     }
 
     /**

--- a/src/Service/Form/ConfigFormFactory.php
+++ b/src/Service/Form/ConfigFormFactory.php
@@ -13,7 +13,7 @@ class ConfigFormFactory implements FactoryInterface
         $settings = $services->get('Omeka\Settings');
 
         $form = new ConfigForm(null, $options);
-        $form->setSettings($settings);
+        $form->setGlobalSettings($settings);
 
         return $form;
     }


### PR DESCRIPTION
I am on Omeka S version 1.3.0 and I can now go in and change the configuration for this module without receiving an error. (I haven't yet tested the actual functionality of the module.)

The first thing I changed was a capitalization error in a class name.
Once that was resolved, I was getting another error. In looking at the Metadata Browse module I made a few changes to make this one match that one. You can see those here https://github.com/omeka-s-modules/MetadataBrowse/blob/develop/src/Service/Form/ConfigFormFactory.php and here https://github.com/omeka-s-modules/MetadataBrowse/blob/develop/src/Form/ConfigForm.php