### PR TITLE
Public Path Prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## \[v3.3.0\] - 2024-08-24
+
+- Add ability to override public path with a prefix, for the purposes of using a CDN
+
 ## \[v3.2.1\] - 2024-06-13
 
 - Add missing use statement in AzureFactory (#49)

--- a/config/module.ini
+++ b/config/module.ini
@@ -5,7 +5,7 @@ tags         = "amazon s3 aws, wasabi, azure, digital ocean, dropbox, google, sc
 author       = "Jared Howland, Jon Fackrell, & Julian Maurice"
 author_link  = "https://www.jaredhowland.com"
 ; Version is automatically updated using GitHub action `release.yml` in case you forget before releasing
-version      = "3.2.1"
+version      = "3.3.0"
 configurable = true
 module_link  = "https://github.com/HBLL-Collection-Development/omeka-s-any-cloud"
 support_link = "https://github.com/HBLL-Collection-Development/omeka-s-any-cloud/issues"

--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -144,6 +144,17 @@ class ConfigForm extends Form
                 'id' => $id.'_endpoint',
             ],
         ]);
+        $awsFieldset->add([
+            'name'    => $id.'_public_path_prefix',
+            'type'    => Element\Text::class,
+            'options' => [
+                'label' => $label.'Public Path Prefix',
+                'info'  => 'Overrides the default public path generation with a custom prefix. Can usually leave blank unless you are using a CDN.',
+            ],
+            'attributes' => [
+                'id' => $id.'_public_path_prefix',
+            ],
+        ]);
     }
 
     /**

--- a/src/Service/File/Adapter/AwsS3V3/AwsS3V3AdapterWrapper.php
+++ b/src/Service/File/Adapter/AwsS3V3/AwsS3V3AdapterWrapper.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace AnyCloud\Service\File\Adapter\AwsS3V3;
+
+use Aws\S3\S3ClientInterface;
+use League\Flysystem\AwsS3V3\AwsS3V3Adapter;
+use League\Flysystem\Config;
+use League\Flysystem\PathPrefixer;
+
+class AwsS3V3AdapterWrapper extends AwsS3V3Adapter
+{
+    private ?PathPrefixer $prefixer;
+
+    public function __construct(
+        private S3ClientInterface $client,
+        private array $config,
+    ) {
+        parent::__construct($client, $config['bucket']);
+
+        $pathPrefix = $this->config['public_path_prefix'];
+        if ($pathPrefix) {
+            $this->prefixer = new PathPrefixer($pathPrefix, '/');
+        } else {
+            $this->prefixer = null;
+        }
+    }
+
+    public function publicUrl(string $path, Config $cnf): string
+    {
+        if ($this->prefixer) {
+            return $this->prefixer->prefixPath($path);
+        }
+
+        return parent::publicUrl($path, $cnf);
+    }
+}

--- a/src/Service/File/Store/AbstractAwsS3V3Factory.php
+++ b/src/Service/File/Store/AbstractAwsS3V3Factory.php
@@ -2,8 +2,8 @@
 
 namespace AnyCloud\Service\File\Store;
 
+use AnyCloud\Service\File\Adapter\AwsS3V3\AwsS3V3AdapterWrapper;
 use Aws\S3\S3Client;
-use League\Flysystem\AwsS3V3\AwsS3V3Adapter;
 use League\Flysystem\FilesystemAdapter;
 
 abstract class AbstractAwsS3V3Factory extends AbstractFlysystemFactory
@@ -20,7 +20,7 @@ abstract class AbstractAwsS3V3Factory extends AbstractFlysystemFactory
             'version'  => 'latest',
         ];
         $client = new S3Client($options);
-        $adapter = new AwsS3V3Adapter($client, $config['bucket']);
+        $adapter = new AwsS3V3AdapterWrapper($client, $config);
 
         return $adapter;
     }


### PR DESCRIPTION
## Description
Adds the ability to customize the public path of AWS files using a custom prefix instead of pulling from the AWS library

## Motivation and context
This makes it possible to use a CDN (like Cloudflare) in-between AWS (or compatible) and the user

## How has this been tested?
* Created Backblaze B2 bucket and configured to work with my Omeka S instance without using this new feature
* Confirmed I can access file attachments and that the URLs are of the form `https://bucketname.s3.region.backblazeb2.com/...`
* Followed instructions at https://www.backblaze.com/blog/free-image-hosting-with-cloudflare-transform-rules-and-backblaze-b2/ to configure to configure Backblaze+Cloudflare
* Added a Public Path Prefix of the form `https://cdn.mydomain.com/file/bucketname` to the AnyCloud settings
* Confirmed I can still access file attachments and that the URLs are of the form `https://cdn.mydomain.com/file/bucketname/...`

## Screenshots (if appropriate)

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
